### PR TITLE
feat: add compounds generic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ProtGenerics
 Title: S4 generic functions for Bioconductor proteomics infrastructure
 Description: S4 generic functions needed by Bioconductor proteomics
 	packages.
-Version: 1.23.1
+Version: 1.23.2
 Author: Laurent Gatto <laurent.gatto@uclouvain.be>
 Maintainer: Laurent Gatto <laurent.gatto@uclouvain.be>
 biocViews: Infrastructure, Proteomics, MassSpectrometry

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 1.23.2
+-------------------------
+o new compounds generic.
+
 CHANGES IN VERSION 1.23.1
 -------------------------
 o new calculateFragments generic (moved from MSnbase)

--- a/R/protgenerics.R
+++ b/R/protgenerics.R
@@ -55,6 +55,8 @@ setGeneric("isolationWindowUpperMz<-", function(object, ..., value) standardGene
 setGeneric("productMz", function(object, ...) standardGeneric("productMz"))
 setGeneric("productMz<-", function(object, ..., value) standardGeneric("productMz<-"))
 
+setGeneric("compounds", function(object, ...) standardGeneric("compounds"))
+
 ## -------------------------------------------------------------
 ## Raw data
 ## -------------------------------------------------------------

--- a/man/protgenerics.Rd
+++ b/man/protgenerics.Rd
@@ -98,6 +98,8 @@
 \alias{filterMz}
 \alias{filterNA}
 \alias{tolerance}
+\alias{calculateFragments}
+\alias{compounds}
 
 \title{
   S4 generic functions for Bioconductor proteomics infrastructure


### PR DESCRIPTION
Add a generic for `compounds`. This method is currently used in the packages `CompoundDb` and `MsBackendMassbank`.