### PR TITLE
Move generics from Spectra

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ProtGenerics
 Title: Generic infrastructure for Bioconductor mass spectrometry packages
 Description: S4 generic functions and classes needed by Bioconductor
         proteomics packages.
-Version: 1.35.3
+Version: 1.35.4
 Author: Laurent Gatto <laurent.gatto@uclouvain.be>,
     Johannes Rainer <johannes.rainer@eurac.edu>
 Maintainer: Laurent Gatto <laurent.gatto@uclouvain.be>

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 1.35.4
+-------------------------
+o Move `backendParallelFactor` and `backendBpparam` and `supportsSetBackend`
+  generics from `Spectra`.
+
 CHANGES IN VERSION 1.35.3
 -------------------------
 o Move `backendInitialize`, `backendMerge`, `setBackend`, `isReadOnly`,

--- a/R/protgenerics.R
+++ b/R/protgenerics.R
@@ -231,6 +231,18 @@ setGeneric("setBackend", function(object, backend, ...)
 setGeneric("backendMerge", function(object, ...)
            standardGeneric("backendMerge"))
 
+#' @rdname backendInitialize
+setGeneric("backendBpparam", def = function(object, ...)
+    standardGeneric("backendBpparam"))
+
+#' @rdname backendInitialize
+setGeneric("backendParallelFactor", def = function(object, ...)
+    standardGeneric("backendParallelFactor"))
+
+#' @rdname backendInitialize
+setGeneric("supportsSetBackend", function(object, ...)
+    standardGeneric("supportsSetBackend"))
+
 #' @title Get or set MS peak data
 #'
 #' @description

--- a/man/backendInitialize.Rd
+++ b/man/backendInitialize.Rd
@@ -5,6 +5,9 @@
 \alias{isReadOnly}
 \alias{setBackend}
 \alias{backendMerge}
+\alias{backendBpparam}
+\alias{backendParallelFactor}
+\alias{supportsSetBackend}
 \title{General backend methods}
 \usage{
 backendInitialize(object, ...)
@@ -14,6 +17,12 @@ isReadOnly(object)
 setBackend(object, backend, ...)
 
 backendMerge(object, ...)
+
+backendBpparam(object, ...)
+
+backendParallelFactor(object, ...)
+
+supportsSetBackend(object, ...)
 }
 \arguments{
 \item{object}{The \emph{backend} object.}


### PR DESCRIPTION
- Move `backendBpparam`, `backendParallelFactor` and `supportsSetBackend` from `Spectra`.