### PR TITLE
feat: add storeResults and loadResults generics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ProtGenerics
 Title: Generic infrastructure for Bioconductor mass spectrometry packages
 Description: S4 generic functions and classes needed by Bioconductor
         proteomics packages.
-Version: 1.37.0
+Version: 1.37.1
 Author: Laurent Gatto <laurent.gatto@uclouvain.be>,
     Johannes Rainer <johannes.rainer@eurac.edu>
 Maintainer: Laurent Gatto <laurent.gatto@uclouvain.be>

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 1.37.1
+-------------------------
+o Add generics for methods `storeResults()` and `loadResults()`.
+
 CHANGES IN VERSION 1.35.4
 -------------------------
 o Move `backendParallelFactor` and `backendBpparam` and `supportsSetBackend`

--- a/R/protgenerics.R
+++ b/R/protgenerics.R
@@ -270,3 +270,31 @@ setGeneric("peaksData<-", function(object, value)
 #' @rdname peaksData
 setGeneric("peaksVariables", function(object, ...)
     standardGeneric("peaksVariables"))
+
+#' @title Store and load data objects and results
+#'
+#' @description
+#'
+#' `storeResults()` and `loadResults()` allow to save and restore data objects
+#' in format(s) defined by parameter `param`. These methods thus allow to
+#' implement serializing and deserializing functions for (result) objects in
+#' formats other than the e.g. standard RData format. Also, the user can define
+#' the expected type of the returned object with the `object` parameter of
+#' `loadResults()`.
+#'
+#' @param object For `storeResults()`: the object to be exported. For
+#'     `loadResults()`: the type of object that is expected to be returned.
+#'
+#' @param param A *parameter* object that defines the format and eventually
+#'     specific settings for that format.
+#'
+#' @param ... Optional parameters.
+#' @md
+#' 
+#' @name storeResults
+setGeneric("storeResults", function(object, param, ...),
+    standardGeneric("storeResults"))
+
+#' @rdname storeResults
+setGeneric("loadResults", function(object, param, ...),
+    standardGeneric("loadResults"))


### PR DESCRIPTION
As a background info/use case: in xcms we want to allow users to store/load the *result* objects (which are `MsExperiment` and `XcmsExperiment` objects) during or after the analysis in different formats to allow an integration of the data/results in other (external) software. On top of the plain RData format, that can only be read/used by R, we also have plain text file formats (for better/safer Galaxy integration) and @philouail is also working on a MzTab-M export (/import).

These methods should provide a *unified* interface for these operations. The user could e.g. export the data in plain text format, or MzTab format using:

```r
storeResults(xmse, param = PlainTextParam())
storeResults(xmse, param = MzTabParam())
```

Also, we then plan to have something like

```r
loadResults(SummarizedExperiment(), param = MzTabParam())
```

to allow import of results from other software into R. The reason to add these into ProtGenerics is that we need to have these methods also implemented for `Spectra`, `MsBackendMzR` etc.